### PR TITLE
feat: ship es2019 compatbile code with no optional chaining in dist

### DIFF
--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2019",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",
-    "lib": ["es2020", "DOM", "ES2015"],
+    "lib": ["DOM", "ES2015", "ES2019"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
- Support Create React App v4 (current) and Vue CLI out of the box
- Closes #61 

cc @RetricSu 