### PR TITLE
fix: make godwoken package strict tsconfig compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "^7.30.0"
   },
   "devDependencies": {
-    "commander": "^8.0.0"
+    "commander": "^8.0.0",
+    "typescript": "^4.4.4"
   }
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -51,7 +51,6 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^8.0.12",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.3",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^3.0.0"

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -50,7 +50,6 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^8.0.12",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.3",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^3.0.0"

--- a/packages/godwoken/src/normalizer.ts
+++ b/packages/godwoken/src/normalizer.ts
@@ -51,9 +51,9 @@ function normalizeRawData(length: number) {
   return function (debugPath: string, value: any) {
     try {
       value = new Reader(value).toArrayBuffer();
-    } catch (error) {
+    } catch (error: any) {
       throw new Error(
-        `${debugPath} invalid value ${value}, error: ${error.message}`
+        `${debugPath} invalid value ${value}, error: ${error?.message}`
       );
     }
     if (length > 0 && value.byteLength !== length) {

--- a/packages/godwoken/tsconfig.json
+++ b/packages/godwoken/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "strict": true
   },
   "exclude": ["node_modules", "tests", "lib", "schemas"],
   "include": ["src"]

--- a/packages/godwoken/tsconfig.json
+++ b/packages/godwoken/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2019",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",
-    "lib": ["es2020", "DOM"],
+    "lib": ["DOM", "ES2015", "ES2019"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -53,7 +53,6 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^8.0.12",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.3",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^3.0.0"

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -55,7 +55,6 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^8.0.12",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.3",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6919,10 +6919,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.3:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 ultron@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Changes:
1. Move typescript package to global package.json and remove it from individual package.json to avoid repetition
2. Fix @polyjuice-provider/godwoken compatibility with TypeScript 4.4 when "strict" in tsconfig.json is set to true
3. Use ES2019 for @polyjuice-provider/godwoken compatibility with Create React App

Fixed problem:
![image](https://user-images.githubusercontent.com/4950658/141994088-db37ca5a-f755-4717-8153-81cadf00f045.png)

Literature:
1. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables
2. https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables (default to true when strict true)

Please review @RetricSu 