### PR TITLE
fix(deps): install cross-fetch & jsbi for lumos peerDeps

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -41,7 +41,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "browser-env": "^3.3.0",
     "browserify": "^17.0.0",
-    "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^10.0.0",
     "husky": "^6.0.0",

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -40,7 +40,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "browser-env": "^3.3.0",
     "browserify": "^17.0.0",
-    "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^10.0.0",
     "husky": "^6.0.0",

--- a/packages/godwoken/package.json
+++ b/packages/godwoken/package.json
@@ -38,6 +38,8 @@
     "@ckb-lumos/base": "0.18.0-rc6",
     "@ckb-lumos/toolkit": "0.18.0-rc6",
     "immutable": "^4.0.0-rc.12",
-    "keccak256": "^1.0.2"
+    "keccak256": "^1.0.2",
+    "cross-fetch": "^3.1.4",
+    "jsbi": "^4.1.0"
   }
 }

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -43,7 +43,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "browser-env": "^3.3.0",
     "browserify": "^17.0.0",
-    "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^10.0.0",
     "husky": "^6.0.0",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -49,7 +49,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "browser-env": "^3.3.0",
     "browserify": "^17.0.0",
-    "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^10.0.0",
     "husky": "^6.0.0",


### PR DESCRIPTION
since lumos/toolkit use peerDependencies for cross-fetch/jsbi, the version 0.1.4 of provider might throw the following error:

```sh
./node_modules/@ckb-lumos/toolkit/lib/rpc.js
Module not found: Can't resolve 'cross-fetch' in '/Users/retric/Desktop/release-workspace/polyjuice-provider-example/node_modules/@ckb-lumos/toolkit/lib'
```

this PR fix this by:

- install cross-fetch/jsbi in godwoken submodules, other submodules all depend on godwoken, so that should be enough
- remove the un-needed cross-fetch in devDependencies in all submodules.